### PR TITLE
Fix mobile navigation and footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
-# tema_acc
+# Tema ACC
+
+Questo tema WordPress è pensato per presentare l'annuncio di Alberto alla ricerca di un accompagnatore personale. Di seguito trovi le istruzioni principali per l'installazione e l'utilizzo.
+
+## Installazione
+
+1. Copia la cartella del tema nella directory `wp-content/themes` del tuo sito WordPress.
+2. Dal pannello di amministrazione attiva il tema "Tema ACC".
+3. Associa un menu alla posizione **Primary Menu** tramite la sezione Aspetto → Menu.
+
+## Caratteristiche
+
+- Navigazione responsive con pulsante mobile.
+- Fogli di stile semplificati per una rapida personalizzazione.
+
+## Licenza
+
+Questo progetto è distribuito con licenza MIT.

--- a/footer.php
+++ b/footer.php
@@ -1,18 +1,7 @@
   <footer>
-    <p>&copy; <?php echo date('Y'); ?> Alberto G – Grazie per aver letto</p>
+    <p>&copy; <?php echo date('Y'); ?> by Alberto Gatti</p>
   </footer>
 <script src="https://www.google.com/recaptcha/api.js" async defer></script>
-<?php include('nav-menu.php')?>
-<script>
-  document.addEventListener("DOMContentLoaded", function () {
-    const toggle = document.querySelector(".mobile");
-    const menu = document.querySelector(".nav-links");
-
-    toggle.addEventListener("click", function () {
-      menu.classList.toggle("active");
-    });
-  });
-</script>
 <?php wp_footer();?>
 </body>
 </html>

--- a/functions.php
+++ b/functions.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * Theme setup functions
+ */
+
+function tema_acc_setup() {
+    register_nav_menus( array(
+        'primary' => __( 'Primary Menu', 'tema_acc' ),
+    ) );
+}
+add_action( 'after_setup_theme', 'tema_acc_setup' );
+

--- a/header.php
+++ b/header.php
@@ -28,22 +28,11 @@
   "image": "https://www.tuosito.it/wp-content/themes/il-mio-accompagnatore/images/main.jpg"
 }
 </script>
-	<?php include('nav-menu.php')?>
 </head>
 <body>
   <header>
-<script>
-  document.addEventListener("DOMContentLoaded", function () {
-    const toggle = document.querySelector('.menu-toggle');
-    const navLinks = document.querySelector('.nav-links');
+    <?php include('nav-menu.php'); ?>
 
-    toggle.addEventListener('click', function () {
-      navLinks.classList.toggle('active');
-      toggle.classList.toggle('active');
-    });
-  });
-</script>
-
-	  <h1>Il mio accompagnatore ideale</h1>
+    <h1>Il mio accompagnatore ideale</h1>
     <p>Una richiesta di compagnia vera, fatta col cuore</p>
   </header>

--- a/style.css
+++ b/style.css
@@ -243,7 +243,7 @@ footer {
 .sf-arrows .sf-with-ul{
   padding-right: 32px;
 }
-primary-navigation ul{
+.primary-navigation ul{
   list-style: none;
   margin:0;
 }


### PR DESCRIPTION
## Summary
- move navigation include from `<head>` to `<header>`
- remove duplicate mobile scripts and footer menu
- register `primary` menu location
- correct CSS selector for `.primary-navigation`
- expand documentation
- update footer copyright

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6855082f01f4832783edf50e16747918