### PR TITLE
Add menu close behaviors

### DIFF
--- a/nav-menu.php
+++ b/nav-menu.php
@@ -29,10 +29,28 @@ document.addEventListener('DOMContentLoaded', function () {
     return;
   }
 
+  function closeMenu() {
+    menu.classList.remove('active');
+    toggle.classList.remove('active');
+    toggle.setAttribute('aria-expanded', 'false');
+  }
+
   toggle.addEventListener('click', function () {
-    menu.classList.toggle('active');
-    toggle.classList.toggle('active');
-    toggle.setAttribute('aria-expanded', menu.classList.contains('active') ? 'true' : 'false');
+    const isOpen = menu.classList.toggle('active');
+    toggle.classList.toggle('active', isOpen);
+    toggle.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+  });
+
+  document.addEventListener('click', function (e) {
+    if (!menu.classList.contains('active')) return;
+    if (menu.contains(e.target) || toggle.contains(e.target)) return;
+    closeMenu();
+  });
+
+  document.addEventListener('keydown', function (e) {
+    if ((e.key === 'Escape' || e.key === 'Esc') && menu.classList.contains('active')) {
+      closeMenu();
+    }
   });
 });
 </script>


### PR DESCRIPTION
## Summary
- close mobile menu on ESC press or when clicking outside of it
- keep `aria-expanded` in sync when the menu is toggled

## Testing
- `php -l nav-menu.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855114846788327a41f0a3008f4e485